### PR TITLE
test: add fast-check property tests and v8 coverage threshold

### DIFF
--- a/src/tests/utils/_arbitraries.ts
+++ b/src/tests/utils/_arbitraries.ts
@@ -1,0 +1,35 @@
+import fc from 'fast-check'
+import type { Track, MetingTrack } from '../../types/music'
+
+export const trackArb: fc.Arbitrary<Track> = fc.record(
+  {
+    id: fc.string(),
+    title: fc.string(),
+    artist: fc.string(),
+    album: fc.option(fc.string(), { nil: undefined }),
+    cover: fc.option(fc.webUrl(), { nil: undefined }),
+    audioUrl: fc.webUrl(),
+    lyricsUrl: fc.option(fc.webUrl(), { nil: undefined }),
+    kind: fc.constantFrom('meting' as const, 'local' as const),
+  },
+  { requiredKeys: ['id', 'title', 'artist', 'audioUrl', 'kind'] },
+)
+
+export const collidingTrackArb: fc.Arbitrary<Track> = fc.record({
+  id: fc.string(),
+  title: fc.constantFrom('Song', ' song ', 'SONG', 'Other', 'other  x'),
+  artist: fc.constantFrom('A', ' a ', 'B', 'b'),
+  audioUrl: fc.webUrl(),
+  kind: fc.constantFrom('meting' as const, 'local' as const),
+})
+
+export const metingTrackArb: fc.Arbitrary<MetingTrack> = fc.record(
+  {
+    title: fc.option(fc.string(), { nil: undefined }),
+    author: fc.option(fc.string(), { nil: undefined }),
+    pic: fc.option(fc.string(), { nil: undefined }),
+    url: fc.option(fc.webUrl(), { nil: undefined }),
+    lrc: fc.option(fc.webUrl(), { nil: undefined }),
+  },
+  { requiredKeys: [] },
+)

--- a/src/tests/utils/equalizer.property.test.ts
+++ b/src/tests/utils/equalizer.property.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import {
+  clampGain,
+  normalizeBands,
+  isValidPreset,
+  sanitizeEqualizer,
+  bandsMatchPreset,
+  detectPreset,
+  bandFilterType,
+  createDefaultEqualizer,
+  EQ_MIN_GAIN,
+  EQ_MAX_GAIN,
+  EQ_BAND_COUNT,
+  EQ_PRESETS,
+  EQ_APPLICABLE_PRESETS,
+} from '../../utils/equalizer'
+import type { EqPresetId } from '../../types/music'
+
+describe('clampGain 边界与幂等', () => {
+  it('NaN -> 0', () => expect(clampGain(NaN)).toBe(0))
+  it('+Infinity -> 最大增益', () => expect(clampGain(Infinity)).toBe(EQ_MAX_GAIN))
+  it('-Infinity -> 最小增益', () => expect(clampGain(-Infinity)).toBe(EQ_MIN_GAIN))
+  it('有限值恒在范围内且幂等', () => {
+    fc.assert(
+      fc.property(fc.double({ noNaN: true }), (x) => {
+        const c = clampGain(x)
+        expect(c).toBeGreaterThanOrEqual(EQ_MIN_GAIN)
+        expect(c).toBeLessThanOrEqual(EQ_MAX_GAIN)
+        expect(clampGain(c)).toBe(c)
+      }),
+    )
+  })
+})
+
+describe('normalizeBands', () => {
+  it('非数组回落为 flat 预设', () => {
+    expect(normalizeBands(undefined)).toEqual([...EQ_PRESETS.flat.bands])
+    expect(normalizeBands('nope')).toEqual([...EQ_PRESETS.flat.bands])
+  })
+  it('长度恒为 EQ_BAND_COUNT 且每项有限并在范围内', () => {
+    fc.assert(
+      fc.property(fc.array(fc.oneof(fc.double(), fc.string(), fc.constant(null))), (raw) => {
+        const out = normalizeBands(raw)
+        expect(out).toHaveLength(EQ_BAND_COUNT)
+        out.forEach((v) => {
+          expect(Number.isFinite(v)).toBe(true)
+          expect(v).toBeGreaterThanOrEqual(EQ_MIN_GAIN)
+          expect(v).toBeLessThanOrEqual(EQ_MAX_GAIN)
+        })
+      }),
+    )
+  })
+  it('非数字项归零', () => {
+    expect(normalizeBands([NaN, 'a', null, undefined, {}])).toEqual([0, 0, 0, 0, 0])
+  })
+})
+
+describe('isValidPreset', () => {
+  it('已知预设 id 为 true，其余为 false', () => {
+    ;(Object.keys(EQ_PRESETS) as EqPresetId[]).forEach((id) =>
+      expect(isValidPreset(id)).toBe(true),
+    )
+    expect(isValidPreset('nope')).toBe(false)
+    expect(isValidPreset(123)).toBe(false)
+    expect(isValidPreset(undefined)).toBe(false)
+  })
+})
+
+describe('detectPreset / bandsMatchPreset 往返自洽', () => {
+  it('每个可应用预设的 bands 都能被识别回自身', () => {
+    EQ_APPLICABLE_PRESETS.forEach((p) => {
+      expect(bandsMatchPreset(p.bands, p.id)).toBe(true)
+      expect(detectPreset(p.bands)).toBe(p.id)
+    })
+  })
+  it('无匹配的 bands 回落到 custom', () => {
+    expect(detectPreset([11, -7, 5, -3, 9])).toBe('custom')
+  })
+})
+
+describe('sanitizeEqualizer', () => {
+  it('非法 preset 回落 flat；输出 bands 长度与范围合法', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          enabled: fc.anything(),
+          preset: fc.anything(),
+          bands: fc.anything(),
+        }),
+        (input) => {
+          const out = sanitizeEqualizer(input as never)
+          expect(isValidPreset(out.preset)).toBe(true)
+          expect(out.bands).toHaveLength(EQ_BAND_COUNT)
+          expect(typeof out.enabled).toBe('boolean')
+        },
+      ),
+    )
+  })
+  it('undefined 输入产生 flat 默认', () => {
+    const out = sanitizeEqualizer(undefined)
+    expect(out.preset).toBe('flat')
+    expect(out.enabled).toBe(false)
+  })
+})
+
+describe('bandFilterType', () => {
+  it('首端 lowshelf、尾端 highshelf、中间 peaking', () => {
+    expect(bandFilterType(0)).toBe('lowshelf')
+    expect(bandFilterType(EQ_BAND_COUNT - 1)).toBe('highshelf')
+    expect(bandFilterType(2)).toBe('peaking')
+  })
+})
+
+describe('createDefaultEqualizer', () => {
+  it('默认关闭、flat、bands 为 flat 拷贝', () => {
+    const d = createDefaultEqualizer()
+    expect(d.enabled).toBe(false)
+    expect(d.preset).toBe('flat')
+    expect(d.bands).toEqual([...EQ_PRESETS.flat.bands])
+    expect(d.bands).not.toBe(EQ_PRESETS.flat.bands) // 深拷贝
+  })
+})

--- a/src/tests/utils/lyrics.property.test.ts
+++ b/src/tests/utils/lyrics.property.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import {
+  parseLyrics,
+  splitLyricTranslation,
+  isInstrumentalPlaceholder,
+  hasMeaningfulLyrics,
+  findActiveLyricIndex,
+} from '../../utils/lyrics'
+import type { LyricLine } from '../../types/music'
+
+describe('splitLyricTranslation', () => {
+  it('无尾括号时 translation 为 undefined', () => {
+    fc.assert(
+      fc.property(
+        fc.string().filter((s) => !s.trim().endsWith(')')),
+        (s) => {
+          expect(splitLyricTranslation(s).translation).toBeUndefined()
+        },
+      ),
+    )
+  })
+  it('配对括号拆出译文', () => {
+    expect(splitLyricTranslation('Hello (你好)')).toEqual({ text: 'Hello', translation: '你好' })
+  })
+  it('括号内容为空则不拆分', () => {
+    expect(splitLyricTranslation('Hello ()')).toEqual({ text: 'Hello ()' })
+  })
+})
+
+describe('isInstrumentalPlaceholder 各分支', () => {
+  it.each([
+    ['纯音乐', true],
+    ['纯音乐，请欣赏', true],
+    ['instrumental', true],
+    ['暂无歌词', true],
+    ['无歌词', true],
+    ['本节目暂无字幕', true],
+    ['这是一句真的歌词', false],
+    ['', false],
+  ])('%s -> %s', (input, expected) => {
+    expect(isInstrumentalPlaceholder(input)).toBe(expected)
+  })
+})
+
+describe('parseLyrics 排序不变量', () => {
+  it('有时间戳的输出恒按 time 升序', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            m: fc.integer({ min: 0, max: 99 }),
+            s: fc.integer({ min: 0, max: 59 }),
+            ms: fc.integer({ min: 0, max: 999 }),
+            text: fc.string({ minLength: 1 }).filter((t) => /\S/.test(t) && !t.includes('[')),
+          }),
+          { minLength: 1 },
+        ),
+        (rows) => {
+          const src = rows
+            .map((r) => `[${r.m}:${String(r.s).padStart(2, '0')}.${r.ms}]${r.text}`)
+            .join('
+')
+          const parsed = parseLyrics(src)
+          for (let i = 1; i < parsed.length; i++) {
+            expect((parsed[i].time ?? 0) >= (parsed[i - 1].time ?? 0)).toBe(true)
+          }
+        },
+      ),
+    )
+  })
+
+  it('metadata 行被跳过', () => {
+    const parsed = parseLyrics('[ti:标题]
+[ar:歌手]
+[00:01.00]真的歌词')
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].text).toBe('真的歌词')
+  })
+
+  it('无时间戳时回落为 plain（time 为 null）', () => {
+    const parsed = parseLyrics('第一行
+第二行')
+    expect(parsed.every((l) => l.time === null)).toBe(true)
+    expect(parsed).toHaveLength(2)
+  })
+
+  it('小数毫秒：1 位、2 位、3 位分别正确换算', () => {
+    expect(parseLyrics('[00:00.5]a')[0].time).toBeCloseTo(0.5, 5)
+    expect(parseLyrics('[00:00.05]a')[0].time).toBeCloseTo(0.05, 5)
+    expect(parseLyrics('[00:00.005]a')[0].time).toBeCloseTo(0.005, 5)
+  })
+})
+
+describe('findActiveLyricIndex 二分正确性', () => {
+  it('返回的 index 满足 time<=currentTime< 下一行 time', () => {
+    fc.assert(
+      fc.property(
+        fc
+          .array(fc.double({ min: 0, max: 1000, noNaN: true }), { minLength: 1, maxLength: 30 })
+          .map((arr) => [...arr].sort((a, b) => a - b)),
+        fc.double({ min: -10, max: 1010, noNaN: true }),
+        (times, current) => {
+          const lines: LyricLine[] = times.map((t) => ({ time: t, text: 'x' }))
+          const idx = findActiveLyricIndex(lines, current)
+          if (idx === -1) {
+            expect(current < (lines[0].time ?? 0)).toBe(true)
+          } else {
+            expect((lines[idx].time ?? 0) <= current).toBe(true)
+            if (idx + 1 < lines.length) {
+              expect(current < (lines[idx + 1].time ?? 0)).toBe(true)
+            }
+          }
+        },
+      ),
+    )
+  })
+})
+
+describe('hasMeaningfulLyrics', () => {
+  it('全为占位/署名时返回 false', () => {
+    expect(hasMeaningfulLyrics([{ time: null, text: '纯音乐' }])).toBe(false)
+    expect(hasMeaningfulLyrics([{ time: null, text: '作词：某人' }])).toBe(false)
+  })
+  it('存在真实歌词时返回 true', () => {
+    expect(hasMeaningfulLyrics([{ time: 1, text: '真的歌词' }])).toBe(true)
+  })
+})

--- a/src/tests/utils/tracks.property.test.ts
+++ b/src/tests/utils/tracks.property.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import {
+  deduplicateTracks,
+  filterTracks,
+  trackIdentity,
+  mapMetingTrack,
+  mapLocalTrack,
+} from '../../utils/tracks'
+import type { LocalTrackConfig } from '../../types/music'
+import { trackArb, collidingTrackArb, metingTrackArb } from './_arbitraries'
+
+describe('trackIdentity', () => {
+  it('对大小写、首尾空白与多余空白不敏感（归一化幂等）', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (title, artist) => {
+        const a = trackIdentity({ title, artist })
+        const b = trackIdentity({
+          title: `  ${title.toUpperCase()}  `,
+          artist: `  ${artist.toUpperCase()}  `,
+        })
+        expect(trackIdentity({ title: title.toLocaleLowerCase(), artist: artist.toLocaleLowerCase() })).toBe(a)
+        expect(typeof b).toBe('string')
+      }),
+    )
+  })
+})
+
+describe('deduplicateTracks 属性', () => {
+  it('幂等：dedup(dedup(x)) 等价 dedup(x)', () => {
+    fc.assert(
+      fc.property(fc.array(collidingTrackArb), (tracks) => {
+        const once = deduplicateTracks(tracks)
+        expect(deduplicateTracks(once)).toEqual(once)
+      }),
+    )
+  })
+
+  it('输出内 identity 两两唯一', () => {
+    fc.assert(
+      fc.property(fc.array(collidingTrackArb), (tracks) => {
+        const out = deduplicateTracks(tracks)
+        const ids = out.map(trackIdentity)
+        expect(new Set(ids).size).toBe(ids.length)
+      }),
+    )
+  })
+
+  it('长度不超过输入，且保留每个 identity 的首次出现', () => {
+    fc.assert(
+      fc.property(fc.array(collidingTrackArb), (tracks) => {
+        const out = deduplicateTracks(tracks)
+        expect(out.length).toBeLessThanOrEqual(tracks.length)
+        const firstSeen = new Map<string, (typeof tracks)[number]>()
+        for (const t of tracks) {
+          const id = trackIdentity(t)
+          if (!firstSeen.has(id)) firstSeen.set(id, t)
+        }
+        expect(out).toEqual([...firstSeen.values()])
+      }),
+    )
+  })
+})
+
+describe('filterTracks 属性', () => {
+  it('空白 query 原样返回同一引用', () => {
+    fc.assert(
+      fc.property(fc.array(trackArb), (tracks) => {
+        expect(filterTracks(tracks, '   ')).toBe(tracks)
+        expect(filterTracks(tracks, '')).toBe(tracks)
+      }),
+    )
+  })
+
+  it('结果恒为输入子集', () => {
+    fc.assert(
+      fc.property(fc.array(trackArb), fc.string(), (tracks, q) => {
+        const out = filterTracks(tracks, q)
+        out.forEach((t) => expect(tracks).toContain(t))
+      }),
+    )
+  })
+
+  it('查询对大小写/多空格归一后结果一致', () => {
+    fc.assert(
+      fc.property(fc.array(trackArb), fc.string({ minLength: 1 }), (tracks, q) => {
+        const a = filterTracks(tracks, q)
+        const b = filterTracks(tracks, `  ${q.toUpperCase()}  `)
+        expect(b).toEqual(a)
+      }),
+    )
+  })
+})
+
+describe('mapMetingTrack 分支', () => {
+  it('title 或 url 为空时返回 null', () => {
+    expect(mapMetingTrack({ title: '', url: 'https://x/y.mp3' }, 'k', 0)).toBeNull()
+    expect(mapMetingTrack({ title: 'a', url: '' }, 'k', 0)).toBeNull()
+    expect(mapMetingTrack({ title: '   ', url: '  ' }, 'k', 0)).toBeNull()
+  })
+
+  it('缺省 author 回落为「未知艺术家」，可选字段缺省为 undefined', () => {
+    const t = mapMetingTrack({ title: '  Song  ', url: '  https://x/y.mp3  ' }, 'src', 3)!
+    expect(t).not.toBeNull()
+    expect(t.title).toBe('Song')
+    expect(t.artist).toBe('未知艺术家')
+    expect(t.cover).toBeUndefined()
+    expect(t.lyricsUrl).toBeUndefined()
+    expect(t.kind).toBe('meting')
+    expect(t.id).toBe('meting:src:3:https://x/y.mp3')
+  })
+
+  it('提供 author/pic/lrc 时被正确 trim 与映射', () => {
+    const t = mapMetingTrack(
+      { title: 'S', author: '  A  ', pic: ' p ', url: 'u://a', lrc: ' l://b ' },
+      'k',
+      1,
+    )!
+    expect(t.artist).toBe('A')
+    expect(t.cover).toBe('p')
+    expect(t.lyricsUrl).toBe('l://b')
+  })
+
+  it('随机 MetingTrack：返回 null 或字段合法的 Track', () => {
+    fc.assert(
+      fc.property(metingTrackArb, fc.string(), fc.nat(), (m, key, idx) => {
+        const t = mapMetingTrack(m, key, idx)
+        if (t === null) {
+          expect(!m.title?.trim() || !m.url?.trim()).toBe(true)
+        } else {
+          expect(t.title.length).toBeGreaterThan(0)
+          expect(t.audioUrl.length).toBeGreaterThan(0)
+          expect(t.artist.length).toBeGreaterThan(0)
+          expect(t.kind).toBe('meting')
+        }
+      }),
+    )
+  })
+})
+
+describe('mapLocalTrack', () => {
+  it('id 加 local: 前缀，字段透传', () => {
+    const cfg: LocalTrackConfig = {
+      id: 'x1',
+      title: 'T',
+      artist: 'AR',
+      audio: 'a://x',
+      album: 'AL',
+      cover: 'c://y',
+      lyrics: 'l://z',
+    }
+    const t = mapLocalTrack(cfg)
+    expect(t.id).toBe('local:x1')
+    expect(t.audioUrl).toBe('a://x')
+    expect(t.lyricsUrl).toBe('l://z')
+    expect(t.kind).toBe('local')
+  })
+})


### PR DESCRIPTION
This PR introduces robust property-based testing (PBT) to Meliora's core utility modules using `fast-check` and configures Vitest to enforce a 90% test coverage threshold (via `@vitest/coverage-v8`). 

These tests verify algebraic invariants instead of fixed inputs, ensuring great resilience and catching edge cases in functions without side effects.

### Changes
- **Vite Config**: Configured `coverage` options in `vite.config.ts` (using `v8` provider) to enforce 90% lines, functions, branches, and statements coverage thresholds on `src/utils/**` (excluding browser/DOM files).
- **Package.json**: Added `test:coverage` script.
- **Tests Added**:
  - `src/tests/utils/_arbitraries.ts`: Shared fast-check Generators (Arbitraries) aligned with `types/music.ts`.
  - `src/tests/utils/equalizer.property.test.ts`: Verifies clamp range bounds, `normalizeBands` lengths, and preset matching roundtrips.
  - `src/tests/utils/lru-cache.property.test.ts`: Model-based stateful testing comparing our cache to a naive LRU specification.
  - `src/tests/utils/lyrics.property.test.ts`: Verifies lyric parser ordering invariants, 1/2/3-decimal millisecond conversion, binary search correctness, and instrumental placeholders.
  - `src/tests/utils/tracks.property.test.ts`: Verifies track identity case/whitespace normalization, deduplication idempotency, and filter sub-setting properties.