### PR TITLE
fix(architecture): 解耦前端与管理服务并修正音源可用性校验

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ pnpm dev:full     # 前端 + 后端模拟(5175 + 8788)
 
 > ### 🔒 配置文件加密
 >
-> 管理后台保存的所有配置(站点信息、API Token、歌单、Umami / GA ID 等)在写入 GitHub 仓库时**全文 AES-GCM 256 加密**,仓库中只存储 base64 密文。构建期会从中生成公开播放器配置,但 `apiToken` 不会进入前端 bundle;需要 token 的 Meting API 后续应通过专门后端代理支持。
+> 管理后台保存的所有配置(站点信息、API Token、歌单、Umami / GA ID 等)在写入 GitHub 仓库时**全文 AES-GCM 256 加密**,仓库中只存储 base64 密文。构建期会从中生成公开播放器配置,但 `apiToken` 不会进入前端 bundle。播放器仅支持无需鉴权的公开 Meting API,不依赖管理边缘函数代理音源。启用远程歌单且填写 API Token 时,保存与连通测试都会明确拒绝；已有配置仍可读取,请在后台清空 Token 并更换为公开接口,或禁用相关歌单。不要把私密 Token 拼进公开 API 端点。服务端连通测试也不能替代浏览器的跨域访问验证。
 >
 > - **加密密钥**:从 `CONFIG_ENCRYPTION_KEY` 用 PBKDF2(100k 迭代)派生,密钥本身**不落盘、不出现在任何文件中**
 > - **密钥解耦**:`CONFIG_ENCRYPTION_KEY` 专用于加密与签名,`GH_TOKEN` 仅用于 GitHub API 读写,两者独立——`GH_TOKEN` 可随时轮换而不影响已加密的配置

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,46 @@ export default tseslint.config(
     },
   },
   {
+    files: ['shared/**/*.ts', 'server/**/*.ts'],
+    ignores: ['server/tests/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/src/**', 'vue', 'pinia', 'vue-router'],
+              message: '公共契约必须定义在 shared，后端与共享层不能依赖前端源码。',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/admin/services/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '**/composables/**',
+                '**/components/**',
+                '**/views/**',
+                'vue',
+                'pinia',
+                'vue-router',
+              ],
+              message: '服务层通过显式依赖注入通知宿主，不直接依赖 Vue 或视图状态。',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['scripts/**/*.{js,mjs,cjs}', '*.config.{js,mjs,cjs}'],
     languageOptions: {
       globals: { ...globals.node },

--- a/server/core/config-handler.ts
+++ b/server/core/config-handler.ts
@@ -17,7 +17,8 @@ import { defaultMusicConfig } from '../../shared/default-config'
 import { collectManagedAssetPaths } from '../../shared/managed-assets'
 import { logSanitizedError } from './error-handler'
 import { isAllowedUploadPath } from './upload-handler'
-import type { MusicConfig } from '../../src/types/music'
+import type { MusicConfig } from '../../shared/music-config'
+import { getPlaybackSupportError } from '../../shared/playback-support'
 
 const CONFIG_PATH = 'public/config.json'
 
@@ -95,6 +96,13 @@ export async function putConfig(body: unknown, env: Env): Promise<Response> {
   }
 
   const config = result.config!
+  const playbackError = getPlaybackSupportError(config)
+  if (playbackError) {
+    return new Response(JSON.stringify({ error: playbackError }), {
+      status: 400,
+      headers: CONFIG_HEADERS,
+    })
+  }
   const stagedResult = validateStagedUploads(
     request.uploads,
     collectManagedAssetPaths(config),

--- a/server/core/music-api-tester.ts
+++ b/server/core/music-api-tester.ts
@@ -1,6 +1,8 @@
 import type { ConfigPayload } from './types'
 import { validateMusicConfig } from '../../shared/config-schema'
 import { CONFIG_LIMITS } from '../../shared/constants'
+import { buildMetingPlaylistUrl } from '../../shared/music-api'
+import { getPlaybackSupportError } from '../../shared/playback-support'
 import { jsonResponse } from './http'
 import { ResponseTooLargeError, readJsonWithLimit } from './read-json-with-limit'
 
@@ -58,15 +60,8 @@ async function testPlaylistApi(
   config: ConfigPayload,
   playlist: ConfigPayload['playlists'][number],
 ): Promise<PlaylistApiCheck> {
-  const params = new URLSearchParams({
-    server: playlist.server,
-    type: 'playlist',
-    id: playlist.playlistId.trim(),
-  })
-  if (config.apiToken?.trim()) params.set('token', config.apiToken.trim())
-
   try {
-    const response = await fetchWithTimeout(`${config.apiEndpoint.trim()}?${params.toString()}`)
+    const response = await fetchWithTimeout(buildMetingPlaylistUrl(config.apiEndpoint, playlist))
     if (response.status >= 300 && response.status < 400) {
       return {
         server: playlist.server,
@@ -132,6 +127,8 @@ export async function testMusicApi(input: unknown): Promise<Response> {
     return jsonResponse({ error: '配置校验失败', details: validation.errors }, 400)
   }
   const config = validation.config
+  const playbackError = getPlaybackSupportError(config)
+  if (playbackError) return jsonResponse({ error: playbackError }, 400)
 
   const playlists: ConfigPayload['playlists'] = config.playlists.filter(
     (playlist) => playlist.enabled !== false && playlist.playlistId.trim(),

--- a/server/core/types.ts
+++ b/server/core/types.ts
@@ -31,35 +31,7 @@ export interface AdminUser {
   authenticated: boolean
 }
 
-export interface ConfigPayload {
-  siteName: string
-  siteIcon?: string
-  apiEndpoint: string
-  apiToken?: string
-  playlists: Array<{ server: 'netease' | 'tencent'; playlistId: string; enabled?: boolean }>
-  localTracks: Array<{
-    id: string
-    title: string
-    artist: string
-    audio: string
-    album?: string
-    cover?: string
-    lyrics?: string
-  }>
-  githubProxy?: string
-  umami?: {
-    enabled?: boolean
-    scriptUrl?: string
-    websiteId?: string
-  }
-  googleAnalytics?: {
-    enabled?: boolean
-    measurementId?: string
-  }
-  googleSiteVerification?: string
-  customCss?: string
-  customJs?: string
-}
+export type { MusicConfig as ConfigPayload } from '../../shared/music-config'
 
 export interface UploadPayload {
   path: string

--- a/server/tests/config-handler.test.ts
+++ b/server/tests/config-handler.test.ts
@@ -55,6 +55,40 @@ describe('config-handler', () => {
     expect(data).toMatchObject({ siteName: 'Meliora', playlists: [], localTracks: [] })
   })
 
+  it('rejects enabled token sources before writing to GitHub', async () => {
+    const { putConfig } = await import('../core/config-handler')
+    const response = await putConfig(
+      {
+        siteName: 'Meliora',
+        apiEndpoint: 'https://music.example.com/api',
+        apiToken: 'private-token',
+        playlists: [{ server: 'netease', playlistId: '123' }],
+        localTracks: [],
+      },
+      ENV,
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining('暂不支持') })
+    expect(githubMocks.getBranchSnapshot).not.toHaveBeenCalled()
+    expect(githubMocks.createBlob).not.toHaveBeenCalled()
+    expect(githubMocks.commitTreeAtomically).not.toHaveBeenCalled()
+  })
+
+  it('allows disabling legacy token sources without losing the rest of the config', async () => {
+    const { putConfig, getConfig } = await import('../core/config-handler')
+    const env = { ...ENV, DEVELOPMENT: 'true' }
+    const config = {
+      siteName: 'Legacy site',
+      apiEndpoint: 'https://music.example.com/api',
+      apiToken: 'private-token',
+      playlists: [{ server: 'netease', playlistId: '123', enabled: false }],
+      localTracks: [],
+    }
+    expect((await putConfig(config, env)).status).toBe(200)
+    expect(await (await getConfig(env)).json()).toMatchObject(config)
+  })
+
   it('fails closed when GitHub config loading fails', async () => {
     githubMocks.readFile.mockRejectedValue(new Error('GitHub unavailable'))
     const { getConfig } = await import('../core/config-handler')

--- a/server/tests/music-api-tester.test.ts
+++ b/server/tests/music-api-tester.test.ts
@@ -11,6 +11,33 @@ const CONFIG: ConfigPayload = {
 }
 
 describe('music api tester', () => {
+  it('rejects token-dependent playback before making an upstream request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('[]'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await testMusicApi({ ...CONFIG, apiToken: 'private-token' })
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining('暂不支持') })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves existing endpoint query parameters just like the player', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('[]'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await testMusicApi({
+      ...CONFIG,
+      apiEndpoint: 'https://music-api.example.com/playlist?quality=high&id=old',
+      apiToken: '   ',
+    })
+    expect((await response.json()).ok).toBe(true)
+    const requested = new URL(String(fetchMock.mock.calls[0]?.[0]))
+    expect(requested.searchParams.get('quality')).toBe('high')
+    expect(requested.searchParams.getAll('id')).toEqual(['123'])
+    expect(requested.searchParams.get('server')).toBe('netease')
+    expect(requested.searchParams.has('token')).toBe(false)
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
   })

--- a/shared/config-schema.ts
+++ b/shared/config-schema.ts
@@ -5,7 +5,7 @@ import type {
   MusicConfig,
   MusicServer,
   UmamiConfig,
-} from '../src/types/music'
+} from './music-config'
 import { isPublicHttpsUrl, isValidUrl } from './utils/url-validation'
 import { CONFIG_LIMITS } from './constants'
 

--- a/shared/default-config.ts
+++ b/shared/default-config.ts
@@ -1,4 +1,4 @@
-import type { PublicMusicConfig } from '../src/types/music'
+import type { PublicMusicConfig } from './music-config'
 
 export const defaultMusicConfig: PublicMusicConfig = {
   siteName: 'Meliora',

--- a/shared/managed-assets.ts
+++ b/shared/managed-assets.ts
@@ -1,4 +1,4 @@
-import type { MusicConfig } from '../src/types/music'
+import type { MusicConfig } from './music-config'
 
 const MANAGED_MUSIC_PREFIX = './music/'
 const MANAGED_ICON_PATTERN = /^\.\/icon\.(?:png|jpe?g|webp|ico)$/i

--- a/shared/music-api.ts
+++ b/shared/music-api.ts
@@ -1,0 +1,21 @@
+import type { MetingPlaylistConfig } from './music-config'
+
+export function buildMetingPlaylistUrl(
+  apiEndpoint: string,
+  playlist: MetingPlaylistConfig,
+): string {
+  const baseUrl = 'https://meliora.local'
+  const isAbsoluteUrl = /^[a-z][a-z\d+.-]*:/i.test(apiEndpoint)
+  const isProtocolRelativeUrl = apiEndpoint.startsWith('//')
+  const url = new URL(apiEndpoint, baseUrl)
+
+  url.searchParams.set('server', playlist.server)
+  url.searchParams.set('type', 'playlist')
+  url.searchParams.set('id', playlist.playlistId)
+
+  if (isAbsoluteUrl) return url.toString()
+  if (isProtocolRelativeUrl) return `//${url.host}${url.pathname}${url.search}${url.hash}`
+
+  const pathname = apiEndpoint.startsWith('/') ? url.pathname : url.pathname.replace(/^\//, '')
+  return `${pathname}${url.search}${url.hash}`
+}

--- a/shared/music-config.ts
+++ b/shared/music-config.ts
@@ -1,0 +1,47 @@
+export type MusicServer = 'netease' | 'tencent'
+
+export interface MetingPlaylistConfig {
+  server: MusicServer
+  playlistId: string
+  enabled?: boolean
+}
+
+export interface LocalTrackConfig {
+  id: string
+  title: string
+  artist: string
+  audio: string
+  album?: string
+  cover?: string
+  lyrics?: string
+}
+
+export interface UmamiConfig {
+  enabled?: boolean
+  scriptUrl?: string
+  websiteId?: string
+}
+
+export interface GoogleAnalyticsConfig {
+  enabled?: boolean
+  measurementId?: string
+}
+
+export interface PublicMusicConfig {
+  siteName: string
+  siteIcon?: string
+  apiEndpoint: string
+  umami?: UmamiConfig
+  googleAnalytics?: GoogleAnalyticsConfig
+  googleSiteVerification?: string
+  customCss?: string
+  customJs?: string
+  playlists: MetingPlaylistConfig[]
+  localTracks: LocalTrackConfig[]
+}
+
+export interface MusicConfig extends PublicMusicConfig {
+  apiToken?: string
+  githubProxy?: string
+  receivePrereleaseUpdates?: boolean
+}

--- a/shared/playback-support.ts
+++ b/shared/playback-support.ts
@@ -1,0 +1,11 @@
+import type { MusicConfig } from './music-config'
+
+export const TOKEN_PLAYBACK_UNSUPPORTED =
+  '播放器暂不支持需要 Token 的音源，请清空 API Token 并改用无需鉴权的公开接口'
+
+/** 兼容读取旧配置，但管理端不能把受保护音源误判为播放器可用。 */
+export function getPlaybackSupportError(config: MusicConfig): string | null {
+  return config.apiToken?.trim() && config.playlists.some((playlist) => playlist.enabled !== false)
+    ? TOKEN_PLAYBACK_UNSUPPORTED
+    : null
+}

--- a/shared/playback-support.ts
+++ b/shared/playback-support.ts
@@ -5,7 +5,10 @@ export const TOKEN_PLAYBACK_UNSUPPORTED =
 
 /** 兼容读取旧配置，但管理端不能把受保护音源误判为播放器可用。 */
 export function getPlaybackSupportError(config: MusicConfig): string | null {
-  return config.apiToken?.trim() && config.playlists.some((playlist) => playlist.enabled !== false)
+  // playlists 可能缺失:旧配置、以及 fetchConfig 直接把 /api/config 的原始 JSON
+  // 断言成 MusicConfig 而不经校验。兼容读取是这个函数的本分,不能在这里抛
+  const playlists = Array.isArray(config.playlists) ? config.playlists : []
+  return config.apiToken?.trim() && playlists.some((playlist) => playlist.enabled !== false)
     ? TOKEN_PLAYBACK_UNSUPPORTED
     : null
 }

--- a/src/admin/components/LocalTrackEditor.vue
+++ b/src/admin/components/LocalTrackEditor.vue
@@ -3,16 +3,14 @@
   import { ChevronDown, Plus, Trash2, Upload } from '@lucide/vue'
   import type { LocalTrackConfig } from '../../types/music'
   import { LOCAL_TRACK_ID_PATTERN } from '../../../shared/config-schema'
-  import {
-    MAX_UPLOAD_BYTES,
-    MAX_UPLOAD_SIZE_LABEL,
-    uploadFile,
-    type StagedUpload,
-  } from '../services/admin-api'
+  import { MAX_UPLOAD_BYTES, MAX_UPLOAD_SIZE_LABEL, type StagedUpload } from '../services/admin-api'
+  import { useAdminApi } from '../composables/useAdminApi'
   import ConfirmModal from './ConfirmModal.vue'
   import Collapse from '../../components/Collapse.vue'
   import BaseInput from '../../components/BaseInput.vue'
   import { useFileStagingState } from '../composables/useFileStagingState'
+
+  const { uploadFile } = useAdminApi()
 
   const props = defineProps<{ tracks: LocalTrackConfig[] }>()
   const emit = defineEmits<{

--- a/src/admin/components/SecurityEditor.vue
+++ b/src/admin/components/SecurityEditor.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { changePassword } from '../services/admin-api'
+  import { useAdminApi } from '../composables/useAdminApi'
   import BaseInput from '../../components/BaseInput.vue'
   import Toast from '../../components/Toast.vue'
   import { AUTH_CONSTANTS } from '../../../shared/constants'
   import { useTimedMessage } from '../composables/useTimedMessage'
+
+  const { changePassword } = useAdminApi()
 
   const currentPassword = ref('')
   const newPassword = ref('')

--- a/src/admin/components/SiteSettingsEditor.vue
+++ b/src/admin/components/SiteSettingsEditor.vue
@@ -6,12 +6,13 @@
   import {
     MAX_UPLOAD_BYTES,
     MAX_UPLOAD_SIZE_LABEL,
-    testMusicApi,
-    uploadFile,
     type MusicApiTestResult,
     type StagedUpload,
   } from '../services/admin-api'
+  import { useAdminApi } from '../composables/useAdminApi'
   import { useFileStagingState } from '../composables/useFileStagingState'
+
+  const { testMusicApi, uploadFile } = useAdminApi()
 
   const props = defineProps<{ config: MusicConfig }>()
   const emit = defineEmits<{
@@ -90,7 +91,7 @@
         apiTestStatus.value = 'success'
         emit(
           'notify',
-          `全部 ${result.data.playlistCount} 个歌单测试通过,共 ${result.data.trackCount} 首`,
+          `服务端连通测试通过,共 ${result.data.trackCount} 首；请在播放器确认浏览器可访问`,
           'success',
         )
       } else {
@@ -248,13 +249,13 @@
       <div class="setting-row">
         <span class="row-label">
           <strong>API Token</strong>
-          <small>部分 Meting API 需要鉴权</small>
+          <small>暂不支持 Token 音源；请清空 Token 并改用无需鉴权的公开接口</small>
         </span>
         <div class="token-field">
           <BaseInput
             :model-value="config.apiToken || ''"
             :type="showApiToken ? 'text' : 'password'"
-            placeholder="可选"
+            placeholder="暂不支持，请留空"
             @update:model-value="setApiToken($event)"
           />
           <button type="button" class="token-toggle" @click="showApiToken = !showApiToken">
@@ -265,8 +266,8 @@
 
       <div class="setting-row api-test-row">
         <span class="row-label">
-          <strong>连通测试</strong>
-          <small>测试全部启用歌单接口</small>
+          <strong>服务端连通测试</strong>
+          <small>测试公开歌单接口；浏览器跨域访问需在播放器确认</small>
         </span>
         <button
           type="button"

--- a/src/admin/composables/useAdminApi.ts
+++ b/src/admin/composables/useAdminApi.ts
@@ -1,0 +1,8 @@
+import { createAdminApi } from '../services/admin-api'
+import { markAdminUnauthenticated } from './useAdminAuth'
+
+const adminApi = createAdminApi({ onUnauthenticated: markAdminUnauthenticated })
+
+export function useAdminApi(): ReturnType<typeof createAdminApi> {
+  return adminApi
+}

--- a/src/admin/composables/useUpdateStatus.ts
+++ b/src/admin/composables/useUpdateStatus.ts
@@ -1,5 +1,8 @@
 import { readonly, ref } from 'vue'
-import { fetchUpdateStatus, triggerUpdate, type UpdateStatusInfo } from '../services/admin-api'
+import type { UpdateStatusInfo } from '../services/admin-api'
+import { useAdminApi } from './useAdminApi'
+
+const { fetchUpdateStatus, triggerUpdate } = useAdminApi()
 
 export type UpdateRunState =
   | 'idle'

--- a/src/admin/services/admin-api.ts
+++ b/src/admin/services/admin-api.ts
@@ -274,6 +274,9 @@ export function createAdminApi(dependencies: AdminApiDependencies = {}) {
   async function testMusicApi(
     config: MusicConfig,
   ): Promise<{ ok: boolean; data?: MusicApiTestResult; error?: string }> {
+    // 与 saveConfig 不同,这里不放宽私网地址:服务端的 /api/test-music-api
+    // 一律按公网规则校验(server/core/music-api-tester.ts),dev 下放宽只会
+    // 让前端放行、再被服务端以同样的理由拒掉
     const validation = validateMusicConfig(config)
     if (!validation.valid) return { ok: false, error: validation.errors.join('; ') }
     const playbackError = getPlaybackSupportError(validation.config!)
@@ -382,14 +385,3 @@ export function createAdminApi(dependencies: AdminApiDependencies = {}) {
     fetchUpdateStatus,
   }
 }
-
-export const {
-  fetchConfig,
-  saveConfig,
-  uploadFile,
-  changePassword,
-  testMusicApi,
-  checkUpdate,
-  triggerUpdate,
-  fetchUpdateStatus,
-} = createAdminApi()

--- a/src/admin/services/admin-api.ts
+++ b/src/admin/services/admin-api.ts
@@ -1,8 +1,8 @@
 import type { MusicConfig } from '../../types/music'
 import { validateMusicConfig } from '../../../shared/config-schema'
-import { markAdminUnauthenticated } from '../composables/useAdminAuth'
 import { fetchWithCsrf, csrfManager } from '../utils/csrf'
 import { UPLOAD_LIMITS } from '../../../shared/constants'
+import { getPlaybackSupportError } from '../../../shared/playback-support'
 
 export interface SaveResult {
   ok: boolean
@@ -41,61 +41,6 @@ type AdminRequestResult<T> =
   | { ok: true; data: T }
   | { ok: false; data: Partial<T> & ApiErrorPayload; error: string }
 
-function resolveErrorMessage(data: ApiErrorPayload, fallback: string): string {
-  return data.details?.join('; ') || data.detail || data.error || data.message || fallback
-}
-
-async function requestAdminJson<T extends object>(
-  url: string,
-  init: RequestInit,
-  options: {
-    fallbackError: string
-    abortedError?: string
-    markUnauthenticated?: boolean
-    /**
-     * 非幂等请求(如触发部署)置为 false。
-     * 重试安全的前提:服务端的 403 只发生在 CSRF/跨站校验阶段(见 server/core/router.ts),
-     * 此时业务 handler 尚未执行、没有任何副作用;幂等请求重试一次是安全的。
-     */
-    retryOn403?: boolean
-  },
-): Promise<AdminRequestResult<T>> {
-  try {
-    let response = await fetchWithCsrf(url, { ...init, credentials: 'include' })
-    let data = (await response.json().catch(() => ({}))) as Partial<T> & ApiErrorPayload
-
-    // 403 多为 CSRF token 失效(如改密码 bump 版本后旧 token 被吊销):
-    // 清除内存 token 并重试一次,fetchWithCsrf 会在重试前自动重新获取 token。
-    // 已 abort 的请求不重试:复用的 init.signal 已中止,重试会立刻 AbortError,
-    // 把真实错误误报成"已取消"。
-    if (response.status === 403 && options.retryOn403 !== false && !init.signal?.aborted) {
-      csrfManager.clearToken()
-      response = await fetchWithCsrf(url, { ...init, credentials: 'include' })
-      data = (await response.json().catch(() => ({}))) as Partial<T> & ApiErrorPayload
-    }
-
-    if (response.ok) return { ok: true, data: data as T }
-
-    // 仅 401 视为登录过期;403 重试仍失败时按服务端返回的错误提示
-    if (response.status === 401 && options.markUnauthenticated !== false) {
-      markAdminUnauthenticated()
-      return { ok: false, data, error: '登录已过期,请重新登录' }
-    }
-
-    return {
-      ok: false,
-      data,
-      error: resolveErrorMessage(data, options.fallbackError),
-    }
-  } catch (error) {
-    const message =
-      error instanceof DOMException && error.name === 'AbortError'
-        ? options.abortedError || '请求已取消'
-        : '网络错误'
-    return { ok: false, data: {}, error: message }
-  }
-}
-
 export interface ApiPlaylistCheck {
   server: string
   playlistId: string
@@ -111,130 +56,6 @@ export interface MusicApiTestResult {
   failedPlaylists: number
   trackCount: number
   playlists: ApiPlaylistCheck[]
-}
-
-export async function fetchConfig(): Promise<MusicConfig | null> {
-  const result = await requestAdminJson<MusicConfig>(
-    '/api/config',
-    {},
-    { fallbackError: '配置加载失败' },
-  )
-  return result.ok ? result.data : null
-}
-
-export async function saveConfig(
-  config: MusicConfig,
-  uploads: StagedUpload[] = [],
-): Promise<SaveResult> {
-  // 与服务端开发模式一致(server/core/config-handler.ts):
-  // dev 下允许 http://localhost 等私网地址,避免前端误拦
-  const validation = validateMusicConfig(config, { allowPrivateUrls: import.meta.env.DEV })
-  if (!validation.valid) {
-    return { ok: false, error: validation.errors.join('; ') }
-  }
-
-  const result = await requestAdminJson<{ sha?: string }>(
-    '/api/config',
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ config, uploads }),
-    },
-    { fallbackError: '保存失败' },
-  )
-  if (!result.ok) return { ok: false, error: result.error }
-
-  if (import.meta.env.DEV) {
-    const synced = await syncLocalGeneratedConfig(config)
-    if (!synced.ok) {
-      return {
-        ok: true,
-        warning: `后端配置已保存,但本地播放器配置同步失败:${synced.error || '未知错误'}`,
-      }
-    }
-  }
-  return { ok: true }
-}
-
-async function syncLocalGeneratedConfig(
-  config: MusicConfig,
-): Promise<{ ok: boolean; error?: string }> {
-  try {
-    const response = await fetch('/__meliora-dev/config', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(config),
-    })
-    if (!response.ok) {
-      const data = (await response.json().catch(() => ({}))) as {
-        error?: string
-        details?: string[]
-      }
-      return { ok: false, error: data.details?.join('; ') || data.error || '同步失败' }
-    }
-    return { ok: true }
-  } catch {
-    return { ok: false, error: '同步接口不可用' }
-  }
-}
-
-export async function uploadFile(path: string, content: string): Promise<UploadResult> {
-  if (content.length > MAX_UPLOAD_BASE64_LENGTH) {
-    return { ok: false, error: `文件过大,最大 ${MAX_UPLOAD_SIZE_LABEL}` }
-  }
-
-  const result = await requestAdminJson<{ blobSha?: string; path?: string; local?: boolean }>(
-    '/api/upload',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path, content }),
-    },
-    { fallbackError: '上传失败' },
-  )
-  if (!result.ok) return { ok: false, error: result.error }
-  if (!result.data.blobSha || !result.data.path) {
-    return { ok: false, error: '暂存响应不完整,文件未加入待保存列表' }
-  }
-  return {
-    ok: true,
-    blobSha: result.data.blobSha,
-    path: result.data.path,
-    local: result.data.local,
-  }
-}
-
-export async function changePassword(current: string, next: string): Promise<SaveResult> {
-  const result = await requestAdminJson<{ success?: boolean }>(
-    '/api/change-password',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ current, next }),
-    },
-    { fallbackError: '修改失败' },
-  )
-  return result.ok ? { ok: true } : { ok: false, error: result.error }
-}
-
-export async function testMusicApi(
-  config: MusicConfig,
-): Promise<{ ok: boolean; data?: MusicApiTestResult; error?: string }> {
-  const result = await requestAdminJson<MusicApiTestResult>(
-    '/api/test-music-api',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(config),
-    },
-    { fallbackError: '测试失败' },
-  )
-  if (!result.ok) return { ok: false, error: result.error }
-  return {
-    ok: result.data.ok,
-    data: result.data,
-    error: result.data.ok ? undefined : '部分资源测试失败',
-  }
 }
 
 export interface UpdateInfo {
@@ -283,78 +104,292 @@ export interface UpdateStatusInfo {
   retryAfterSeconds?: number
 }
 
-export async function checkUpdate(
-  currentVersion: string,
-  githubProxy?: string,
-  receivePrereleaseUpdates = false,
-  signal?: AbortSignal,
-  options: { markUnauthenticated?: boolean } = {},
-): Promise<{ ok: boolean; data?: UpdateInfo; error?: string }> {
-  const result = await requestAdminJson<UpdateInfo>(
-    '/api/check-update',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        current: currentVersion,
-        githubProxy: githubProxy?.trim() || '',
-        receivePrereleaseUpdates,
-      }),
-      signal,
-    },
-    {
-      fallbackError: '检查失败',
-      abortedError: '检查已取消',
-      markUnauthenticated: options.markUnauthenticated,
-    },
-  )
-  return result.ok ? { ok: true, data: result.data } : { ok: false, error: result.error }
+export interface AdminApiDependencies {
+  onUnauthenticated?: () => void
 }
 
-export async function triggerUpdate(
-  githubProxy?: string,
-  targetTag?: string,
-  receivePrereleaseUpdates = false,
-): Promise<SaveResult> {
-  const result = await requestAdminJson<{
-    message?: string
-    triggeredAt?: string
-    triggerId?: string
-  }>(
-    '/api/update',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        githubProxy: githubProxy?.trim() || '',
-        targetTag: targetTag?.trim() || '',
-        receivePrereleaseUpdates,
-      }),
+export function createAdminApi(dependencies: AdminApiDependencies = {}) {
+  function resolveErrorMessage(data: ApiErrorPayload, fallback: string): string {
+    return data.details?.join('; ') || data.detail || data.error || data.message || fallback
+  }
+
+  async function requestAdminJson<T extends object>(
+    url: string,
+    init: RequestInit,
+    options: {
+      fallbackError: string
+      abortedError?: string
+      markUnauthenticated?: boolean
+      /**
+       * 非幂等请求(如触发部署)置为 false。
+       * 重试安全的前提:服务端的 403 只发生在 CSRF/跨站校验阶段(见 server/core/router.ts),
+       * 此时业务 handler 尚未执行、没有任何副作用;幂等请求重试一次是安全的。
+       */
+      retryOn403?: boolean
     },
-    { fallbackError: '触发失败', retryOn403: false },
-  )
-  if (!result.ok) return { ok: false, error: result.error }
+  ): Promise<AdminRequestResult<T>> {
+    try {
+      let response = await fetchWithCsrf(url, { ...init, credentials: 'include' })
+      let data = (await response.json().catch(() => ({}))) as Partial<T> & ApiErrorPayload
+
+      // 403 多为 CSRF token 失效(如改密码 bump 版本后旧 token 被吊销):
+      // 清除内存 token 并重试一次,fetchWithCsrf 会在重试前自动重新获取 token。
+      // 已 abort 的请求不重试:复用的 init.signal 已中止,重试会立刻 AbortError,
+      // 把真实错误误报成"已取消"。
+      if (response.status === 403 && options.retryOn403 !== false && !init.signal?.aborted) {
+        csrfManager.clearToken()
+        response = await fetchWithCsrf(url, { ...init, credentials: 'include' })
+        data = (await response.json().catch(() => ({}))) as Partial<T> & ApiErrorPayload
+      }
+
+      if (response.ok) return { ok: true, data: data as T }
+
+      // 仅 401 视为登录过期;403 重试仍失败时按服务端返回的错误提示
+      if (response.status === 401 && options.markUnauthenticated !== false) {
+        dependencies.onUnauthenticated?.()
+        return { ok: false, data, error: '登录已过期,请重新登录' }
+      }
+
+      return {
+        ok: false,
+        data,
+        error: resolveErrorMessage(data, options.fallbackError),
+      }
+    } catch (error) {
+      const message =
+        error instanceof DOMException && error.name === 'AbortError'
+          ? options.abortedError || '请求已取消'
+          : '网络错误'
+      return { ok: false, data: {}, error: message }
+    }
+  }
+
+  async function fetchConfig(): Promise<MusicConfig | null> {
+    const result = await requestAdminJson<MusicConfig>(
+      '/api/config',
+      {},
+      { fallbackError: '配置加载失败' },
+    )
+    return result.ok ? result.data : null
+  }
+
+  async function saveConfig(
+    config: MusicConfig,
+    uploads: StagedUpload[] = [],
+  ): Promise<SaveResult> {
+    // 与服务端开发模式一致(server/core/config-handler.ts):
+    // dev 下允许 http://localhost 等私网地址,避免前端误拦
+    const validation = validateMusicConfig(config, { allowPrivateUrls: import.meta.env.DEV })
+    if (!validation.valid) {
+      return { ok: false, error: validation.errors.join('; ') }
+    }
+
+    const playbackError = getPlaybackSupportError(validation.config!)
+    if (playbackError) return { ok: false, error: playbackError }
+
+    const result = await requestAdminJson<{ sha?: string }>(
+      '/api/config',
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ config, uploads }),
+      },
+      { fallbackError: '保存失败' },
+    )
+    if (!result.ok) return { ok: false, error: result.error }
+
+    if (import.meta.env.DEV) {
+      const synced = await syncLocalGeneratedConfig(config)
+      if (!synced.ok) {
+        return {
+          ok: true,
+          warning: `后端配置已保存,但本地播放器配置同步失败:${synced.error || '未知错误'}`,
+        }
+      }
+    }
+    return { ok: true }
+  }
+
+  async function syncLocalGeneratedConfig(
+    config: MusicConfig,
+  ): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const response = await fetch('/__meliora-dev/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      })
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as {
+          error?: string
+          details?: string[]
+        }
+        return { ok: false, error: data.details?.join('; ') || data.error || '同步失败' }
+      }
+      return { ok: true }
+    } catch {
+      return { ok: false, error: '同步接口不可用' }
+    }
+  }
+
+  async function uploadFile(path: string, content: string): Promise<UploadResult> {
+    if (content.length > MAX_UPLOAD_BASE64_LENGTH) {
+      return { ok: false, error: `文件过大,最大 ${MAX_UPLOAD_SIZE_LABEL}` }
+    }
+
+    const result = await requestAdminJson<{ blobSha?: string; path?: string; local?: boolean }>(
+      '/api/upload',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path, content }),
+      },
+      { fallbackError: '上传失败' },
+    )
+    if (!result.ok) return { ok: false, error: result.error }
+    if (!result.data.blobSha || !result.data.path) {
+      return { ok: false, error: '暂存响应不完整,文件未加入待保存列表' }
+    }
+    return {
+      ok: true,
+      blobSha: result.data.blobSha,
+      path: result.data.path,
+      local: result.data.local,
+    }
+  }
+
+  async function changePassword(current: string, next: string): Promise<SaveResult> {
+    const result = await requestAdminJson<{ success?: boolean }>(
+      '/api/change-password',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ current, next }),
+      },
+      { fallbackError: '修改失败' },
+    )
+    return result.ok ? { ok: true } : { ok: false, error: result.error }
+  }
+
+  async function testMusicApi(
+    config: MusicConfig,
+  ): Promise<{ ok: boolean; data?: MusicApiTestResult; error?: string }> {
+    const validation = validateMusicConfig(config)
+    if (!validation.valid) return { ok: false, error: validation.errors.join('; ') }
+    const playbackError = getPlaybackSupportError(validation.config!)
+    if (playbackError) return { ok: false, error: playbackError }
+
+    const result = await requestAdminJson<MusicApiTestResult>(
+      '/api/test-music-api',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      },
+      { fallbackError: '测试失败' },
+    )
+    if (!result.ok) return { ok: false, error: result.error }
+    return {
+      ok: result.data.ok,
+      data: result.data,
+      error: result.data.ok ? undefined : '部分资源测试失败',
+    }
+  }
+
+  async function checkUpdate(
+    currentVersion: string,
+    githubProxy?: string,
+    receivePrereleaseUpdates = false,
+    signal?: AbortSignal,
+    options: { markUnauthenticated?: boolean } = {},
+  ): Promise<{ ok: boolean; data?: UpdateInfo; error?: string }> {
+    const result = await requestAdminJson<UpdateInfo>(
+      '/api/check-update',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          current: currentVersion,
+          githubProxy: githubProxy?.trim() || '',
+          receivePrereleaseUpdates,
+        }),
+        signal,
+      },
+      {
+        fallbackError: '检查失败',
+        abortedError: '检查已取消',
+        markUnauthenticated: options.markUnauthenticated,
+      },
+    )
+    return result.ok ? { ok: true, data: result.data } : { ok: false, error: result.error }
+  }
+
+  async function triggerUpdate(
+    githubProxy?: string,
+    targetTag?: string,
+    receivePrereleaseUpdates = false,
+  ): Promise<SaveResult> {
+    const result = await requestAdminJson<{
+      message?: string
+      triggeredAt?: string
+      triggerId?: string
+    }>(
+      '/api/update',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          githubProxy: githubProxy?.trim() || '',
+          targetTag: targetTag?.trim() || '',
+          receivePrereleaseUpdates,
+        }),
+      },
+      { fallbackError: '触发失败', retryOn403: false },
+    )
+    if (!result.ok) return { ok: false, error: result.error }
+    return {
+      ok: true,
+      message: result.data.message,
+      triggeredAt: result.data.triggeredAt,
+      triggerId: result.data.triggerId,
+    }
+  }
+
+  async function fetchUpdateStatus(
+    since?: string,
+    triggerId?: string,
+    signal?: AbortSignal,
+  ): Promise<{ ok: boolean; data?: UpdateStatusInfo; error?: string }> {
+    const params = new URLSearchParams()
+    if (since) params.set('since', since)
+    if (triggerId) params.set('triggerId', triggerId)
+    const query = params.toString()
+    const result = await requestAdminJson<UpdateStatusInfo>(
+      `/api/update/status${query ? `?${query}` : ''}`,
+      { signal },
+      { fallbackError: '获取更新状态失败', abortedError: '状态查询已取消' },
+    )
+    return result.ok ? { ok: true, data: result.data } : { ok: false, error: result.error }
+  }
   return {
-    ok: true,
-    message: result.data.message,
-    triggeredAt: result.data.triggeredAt,
-    triggerId: result.data.triggerId,
+    fetchConfig,
+    saveConfig,
+    uploadFile,
+    changePassword,
+    testMusicApi,
+    checkUpdate,
+    triggerUpdate,
+    fetchUpdateStatus,
   }
 }
 
-export async function fetchUpdateStatus(
-  since?: string,
-  triggerId?: string,
-  signal?: AbortSignal,
-): Promise<{ ok: boolean; data?: UpdateStatusInfo; error?: string }> {
-  const params = new URLSearchParams()
-  if (since) params.set('since', since)
-  if (triggerId) params.set('triggerId', triggerId)
-  const query = params.toString()
-  const result = await requestAdminJson<UpdateStatusInfo>(
-    `/api/update/status${query ? `?${query}` : ''}`,
-    { signal },
-    { fallbackError: '获取更新状态失败', abortedError: '状态查询已取消' },
-  )
-  return result.ok ? { ok: true, data: result.data } : { ok: false, error: result.error }
-}
+export const {
+  fetchConfig,
+  saveConfig,
+  uploadFile,
+  changePassword,
+  testMusicApi,
+  checkUpdate,
+  triggerUpdate,
+  fetchUpdateStatus,
+} = createAdminApi()

--- a/src/admin/views/AboutView.vue
+++ b/src/admin/views/AboutView.vue
@@ -2,10 +2,13 @@
   import { onBeforeUnmount, onMounted, ref } from 'vue'
   import { GitFork, RefreshCw, ExternalLink, Check, AlertCircle, Loader2 } from '@lucide/vue'
   import { APP_VERSION } from '../../generated/app-version'
-  import { checkUpdate, type UpdateInfo } from '../services/admin-api'
+  import { type UpdateInfo } from '../services/admin-api'
+  import { useAdminApi } from '../composables/useAdminApi'
   import { useUpdateStatus } from '../composables/useUpdateStatus'
   import type { MusicConfig } from '../../types/music'
   import ConfirmModal from '../components/ConfirmModal.vue'
+
+  const { checkUpdate } = useAdminApi()
 
   const REPO_URL = 'https://github.com/abloom25/Meliora'
   const props = defineProps<{ config: MusicConfig }>()

--- a/src/admin/views/DashboardView.vue
+++ b/src/admin/views/DashboardView.vue
@@ -3,7 +3,8 @@
   import { computed, onMounted, ref } from 'vue'
   import { useRouter } from 'vue-router'
   import { useAdminAuth } from '../composables/useAdminAuth'
-  import { fetchConfig, saveConfig, type StagedUpload } from '../services/admin-api'
+  import type { StagedUpload } from '../services/admin-api'
+  import { useAdminApi } from '../composables/useAdminApi'
   import type { MusicConfig } from '../../types/music'
   import { collectManagedAssetPaths } from '../../../shared/managed-assets'
   import AdminSidebar from '../components/AdminSidebar.vue'
@@ -19,6 +20,8 @@
   import AboutView from './AboutView.vue'
   import { useTimedMessage } from '../composables/useTimedMessage'
   import { useFileStagingState } from '../composables/useFileStagingState'
+
+  const { fetchConfig, saveConfig } = useAdminApi()
 
   const router = useRouter()
   const { logout } = useAdminAuth()

--- a/src/composables/useAudioPlayer.ts
+++ b/src/composables/useAudioPlayer.ts
@@ -4,6 +4,7 @@ import { usePlayerStore } from '../stores/player'
 import type { Track } from '../types/music'
 import { shouldUseIOSBackgroundSafeAudio } from '../utils/browser'
 import { useBeatAnalyser } from './useBeatAnalyser'
+import { createBeatVisualRenderer } from '../utils/beat-visuals'
 import { useEqualizer } from './useEqualizer'
 import {
   usePreloadPool,
@@ -42,12 +43,12 @@ function clamp(value: number, min: number, max: number) {
 export interface UseAudioPlayerOptions {
   /**
    * 可选：返回需要每帧同步 `--beat-level` CSS 变量的目标节点列表。
-   * 仅作为透传给 useBeatAnalyser 的 getBeatTargets。
+   * 由节拍渲染适配器消费，与分析器的采样逻辑分离。
    */
   getBeatTargets?: () => readonly (HTMLElement | null | undefined)[]
   /**
    * 可选：返回队列小频谱 meter 节点(`--spectrum-level-N` 写入目标)。
-   * 仅作为透传给 useBeatAnalyser 的 getSpectrumTargets。
+   * 由节拍渲染适配器消费，与分析器的采样逻辑分离。
    */
   getSpectrumTargets?: () => readonly (HTMLElement | null | undefined)[]
 }
@@ -125,14 +126,15 @@ export function useAudioPlayer(options: UseAudioPlayerOptions = {}) {
   }
 
   const { bindFilters: bindEqFilters } = useEqualizer({ settings })
+  const beatVisuals = createBeatVisualRenderer(options)
   const { beatLevel, spectrumLevels, startBeatAnalysis, stopBeatAnalysis } = useBeatAnalyser({
     players,
     getActiveAudio: () => activeAudio,
     isPlaying,
     beatFlashRate: computed(() => settings.value.beatFlashRate),
     beatVisualDelay: computed(() => settings.value.beatVisualDelay),
-    getBeatTargets: options.getBeatTargets,
-    getSpectrumTargets: options.getSpectrumTargets,
+    onBeat: beatVisuals.renderBeat,
+    onSpectrum: beatVisuals.renderSpectrum,
     onEqFiltersReady: bindEqFilters,
     onTainted: (audio) => taintedHandler?.(audio),
   })

--- a/src/composables/useBeatAnalyser.ts
+++ b/src/composables/useBeatAnalyser.ts
@@ -35,17 +35,9 @@ export interface BeatAnalyserOptions {
   beatFlashRate?: Ref<number>
   /** 可选:闪光延迟微调(ms),叠加在自动输出延迟补偿之上,可为负 */
   beatVisualDelay?: Ref<number>
-  /**
-   * 可选：返回需要每帧同步 `--beat-level` / `--beat-sustain` CSS 变量的 DOM 节点列表。
-   * 直接 setProperty 到这些节点可以避免根元素 :style 触发整棵子树样式重算，
-   * 大幅降低 UpdateLayoutTree 频次。
-   */
-  getBeatTargets?: () => readonly (HTMLElement | null | undefined)[]
-  /**
-   * 可选：返回队列小频谱 meter 节点。每帧直接写入 `--spectrum-level-N`,
-   * 避免频谱柱经 Vue 响应式驱动整个播放队列 60fps 重渲染。
-   */
-  getSpectrumTargets?: () => readonly (HTMLElement | null | undefined)[]
+  /** 高频采样结果由宿主消费；分析器不持有视图节点或 CSS 变量。 */
+  onBeat?: (level: number, sustain: number) => void
+  onSpectrum?: (levels: readonly number[]) => void
   /**
    * 可选：当 EQ filter chain 首次创建完毕时回调，把 BiquadFilterNode 数组
    * 交给 useEqualizer 绑定，由其负责按 settings 更新各频段增益。
@@ -61,68 +53,9 @@ export interface BeatAnalyserOptions {
 }
 
 export function useBeatAnalyser(options: BeatAnalyserOptions) {
-  const { players, getActiveAudio, isPlaying, getBeatTargets, getSpectrumTargets } = options
+  const { players, getActiveAudio, isPlaying } = options
   const beatLevel = ref(0)
   const spectrumLevels = ref([0.1, 0.1, 0.1, 0.1, 0.1])
-  // 记录最近一次写到 DOM 的字符串值，避免重复写入触发样式风暴。
-  // 去抖缓存同时绑定主目标元素:目标重挂载(抽屉开合/虚拟列表滚动)后
-  // 即使值未变化也必须重写一轮,否则新元素一直没有内联变量
-  let lastBeatLevelCssValue = ''
-  let lastBeatTarget: HTMLElement | null = null
-  let lastSpectrumCssValues: string[] = []
-  let lastSpectrumTarget: HTMLElement | null = null
-
-  function writeBeatLevelToTargets(level: number, sustain = 0) {
-    if (!getBeatTargets) return
-    const targets = getBeatTargets()
-    const primary = targets.find((el) => el && el.isConnected) ?? null
-    if (!primary) {
-      lastBeatLevelCssValue = ''
-      lastBeatTarget = null
-      return
-    }
-    const nextLevel = level.toFixed(3)
-    const nextSustain = sustain.toFixed(3)
-    const next = `${nextLevel}/${nextSustain}`
-    if (primary === lastBeatTarget && next === lastBeatLevelCssValue) return
-    lastBeatLevelCssValue = next
-    lastBeatTarget = primary
-    for (const el of targets) {
-      // isConnected 守卫：组件卸载或 v-if 隐藏时跳过，避免脏写已脱离 DOM 的节点。
-      if (!el || !el.isConnected) continue
-      el.style.setProperty('--beat-level', nextLevel)
-      el.style.setProperty('--beat-sustain', nextSustain)
-    }
-  }
-
-  function writeSpectrumToTargets(levels: readonly number[]) {
-    if (!getSpectrumTargets) return
-    const targets = getSpectrumTargets()
-    const primary = targets.find((el) => el && el.isConnected) ?? null
-    if (!primary) {
-      lastSpectrumCssValues = []
-      lastSpectrumTarget = null
-      return
-    }
-    const nextValues = levels.map(
-      (level) => `${(Math.max(0.08, Math.min(1, level)) * 100).toFixed(1)}%`,
-    )
-    if (
-      primary === lastSpectrumTarget &&
-      nextValues.every((value, index) => value === lastSpectrumCssValues[index])
-    ) {
-      return
-    }
-    lastSpectrumCssValues = nextValues
-    lastSpectrumTarget = primary
-    for (const el of targets) {
-      if (!el || !el.isConnected) continue
-      nextValues.forEach((value, index) => {
-        el.style.setProperty(`--spectrum-level-${index}`, value)
-      })
-    }
-  }
-
   let audioContext: AudioContext | null = null
   let analyser: AnalyserNode | null = null
   let frequencyData: Uint8Array<ArrayBuffer> | null = null
@@ -244,11 +177,11 @@ export function useBeatAnalyser(options: BeatAnalyserOptions) {
     beatLevel.value = 0
     resetBeatTracking()
     lastFrameAt = 0
-    writeBeatLevelToTargets(0)
+    options.onBeat?.(0, 0)
     prevPercussiveLow?.fill(0)
     hpss?.reset()
     spectrumLevels.value = spectrumLevels.value.map(() => 0.08)
-    writeSpectrumToTargets(spectrumLevels.value)
+    options.onSpectrum?.(spectrumLevels.value)
     if (visibilityListenerRegistered) {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       visibilityListenerRegistered = false
@@ -266,8 +199,8 @@ export function useBeatAnalyser(options: BeatAnalyserOptions) {
     taintedSilenceMs = 0
     lastBeatFrameAt = 0
     spectrumLevels.value = spectrumLevels.value.map((level) => Math.max(0.08, level * 0.82))
-    writeSpectrumToTargets(spectrumLevels.value)
-    writeBeatLevelToTargets(0)
+    options.onSpectrum?.(spectrumLevels.value)
+    options.onBeat?.(0, 0)
   }
 
   function handleVisibilityChange() {
@@ -379,11 +312,11 @@ export function useBeatAnalyser(options: BeatAnalyserOptions) {
       lastObservedCurrentTime = activeAudio.currentTime
       beatLevel.value *= Math.exp(-dt / 0.13)
       sustainLevel *= Math.exp(-dt / 0.3)
-      writeBeatLevelToTargets(beatLevel.value, sustainLevel)
+      options.onBeat?.(beatLevel.value, sustainLevel)
       spectrumLevels.value = spectrumLevels.value.map((level) =>
         Math.max(0.08, level * Math.exp(-dt / 0.084)),
       )
-      writeSpectrumToTargets(spectrumLevels.value)
+      options.onSpectrum?.(spectrumLevels.value)
       if (beatLevel.value > 0.005) beatFrame = window.requestAnimationFrame(updateBeatLevel)
       else stopBeatAnalysis()
       return
@@ -478,8 +411,8 @@ export function useBeatAnalyser(options: BeatAnalyserOptions) {
       (sustainTarget - sustainLevel) * smoothingAlpha(dt, sustainTarget > sustainLevel ? 0.15 : 0.6)
     const delayed = delayedLevels(now, rawLevel, sustainLevel)
     beatLevel.value = delayed.level
-    // 高频写入：直接 setProperty 到目标节点，跳过 Vue reactivity 与根 :style 路径
-    writeBeatLevelToTargets(delayed.level, delayed.sustain)
+    // 同步通知宿主，渲染适配器可直接写 DOM，不需要根样式响应式更新。
+    options.onBeat?.(delayed.level, delayed.sustain)
 
     // 频谱柱五段 Hz 划分(sub/low/mid/high/air)
     const spectrumBands: Array<{ from: number; to: number }> = [
@@ -533,7 +466,7 @@ export function useBeatAnalyser(options: BeatAnalyserOptions) {
       return previous + (target - previous) * smoothingAlpha(dt, tau)
     })
     spectrumLevels.value = nextSpectrum
-    writeSpectrumToTargets(nextSpectrum)
+    options.onSpectrum?.(nextSpectrum)
     beatFrame = window.requestAnimationFrame(updateBeatLevel)
   }
 

--- a/src/services/music-adapters/meting.ts
+++ b/src/services/music-adapters/meting.ts
@@ -1,24 +1,8 @@
+import { buildMetingPlaylistUrl } from '../../../shared/music-api'
 import type { MetingPlaylistConfig, MetingTrack, Track } from '../../types/music'
 import { hasCachedLyrics, loadCombinedLyrics, registerTrackLyrics } from '../lyrics'
 import { mapMetingTrack } from '../../utils/tracks'
 import type { MusicProviderAdapter, MusicProviderContext } from './types'
-
-function buildMetingPlaylistUrl(apiEndpoint: string, playlist: MetingPlaylistConfig): string {
-  const baseUrl = 'https://meliora.local'
-  const isAbsoluteUrl = /^[a-z][a-z\d+.-]*:/i.test(apiEndpoint)
-  const isProtocolRelativeUrl = apiEndpoint.startsWith('//')
-  const url = new URL(apiEndpoint, baseUrl)
-
-  url.searchParams.set('server', playlist.server)
-  url.searchParams.set('type', 'playlist')
-  url.searchParams.set('id', playlist.playlistId)
-
-  if (isAbsoluteUrl) return url.toString()
-  if (isProtocolRelativeUrl) return `//${url.host}${url.pathname}${url.search}${url.hash}`
-
-  const pathname = apiEndpoint.startsWith('/') ? url.pathname : url.pathname.replace(/^\//, '')
-  return `${pathname}${url.search}${url.hash}`
-}
 
 /**
  * 从 Meting 资源地址中取出平台侧歌曲 ID(`?server=&type=&id=`)。

--- a/src/tests/about-update-status.test.ts
+++ b/src/tests/about-update-status.test.ts
@@ -9,11 +9,7 @@ const adminApiMock = vi.hoisted(() => ({
   fetchUpdateStatus: vi.fn(),
 }))
 
-vi.mock('../admin/services/admin-api', () => ({
-  checkUpdate: adminApiMock.checkUpdate,
-  triggerUpdate: adminApiMock.triggerUpdate,
-  fetchUpdateStatus: adminApiMock.fetchUpdateStatus,
-}))
+vi.mock('../admin/composables/useAdminApi', () => ({ useAdminApi: () => adminApiMock }))
 
 vi.mock('../generated/app-version', () => ({
   APP_VERSION: '0.1.0',

--- a/src/tests/admin-about-navigation.test.ts
+++ b/src/tests/admin-about-navigation.test.ts
@@ -21,13 +21,7 @@ vi.mock('../admin/composables/useAdminAuth', () => ({
   }),
 }))
 
-vi.mock('../admin/services/admin-api', () => ({
-  fetchConfig: adminApiMock.fetchConfig,
-  saveConfig: adminApiMock.saveConfig,
-  checkUpdate: adminApiMock.checkUpdate,
-  triggerUpdate: adminApiMock.triggerUpdate,
-  fetchUpdateStatus: adminApiMock.fetchUpdateStatus,
-}))
+vi.mock('../admin/composables/useAdminApi', () => ({ useAdminApi: () => adminApiMock }))
 
 vi.mock('../generated/app-version', () => ({
   APP_VERSION: '0.1.0',

--- a/src/tests/admin-api.test.ts
+++ b/src/tests/admin-api.test.ts
@@ -227,7 +227,8 @@ describe('admin-api', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { uploadFile } = await import('../admin/services/admin-api')
+    const { createAdminApi } = await import('../admin/services/admin-api')
+    const { uploadFile } = createAdminApi()
     const result = await uploadFile('public/music/a/audio.mp3', 'base64')
 
     expect(result.ok).toBe(true)
@@ -273,7 +274,8 @@ describe('admin-api', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { MAX_UPLOAD_BASE64_LENGTH, uploadFile } = await import('../admin/services/admin-api')
+    const { MAX_UPLOAD_BASE64_LENGTH, createAdminApi } = await import('../admin/services/admin-api')
+    const { uploadFile } = createAdminApi()
     const result = await uploadFile(
       'public/music/a/audio.mp3',
       'a'.repeat(MAX_UPLOAD_BASE64_LENGTH),
@@ -367,7 +369,8 @@ describe('admin-api', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { triggerUpdate } = await import('../admin/services/admin-api')
+    const { createAdminApi } = await import('../admin/services/admin-api')
+    const { triggerUpdate } = createAdminApi()
     const result = await triggerUpdate('https://proxy.example/?url={url}', 'v0.3.0', true)
 
     expect(result).toEqual({
@@ -407,7 +410,8 @@ describe('admin-api', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { fetchUpdateStatus } = await import('../admin/services/admin-api')
+    const { createAdminApi } = await import('../admin/services/admin-api')
+    const { fetchUpdateStatus } = createAdminApi()
     const result = await fetchUpdateStatus('2026-06-30T10:00:00.000Z', 'dispatch-123')
 
     expect(result.ok).toBe(true)
@@ -431,7 +435,8 @@ describe('admin-api', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { fetchUpdateStatus } = await import('../admin/services/admin-api')
+    const { createAdminApi } = await import('../admin/services/admin-api')
+    const { fetchUpdateStatus } = createAdminApi()
     const result = await fetchUpdateStatus('2026-06-30T10:00:00.000Z', 'dispatch-123')
 
     expect(result).toEqual({

--- a/src/tests/admin-api.test.ts
+++ b/src/tests/admin-api.test.ts
@@ -24,6 +24,86 @@ describe('admin-api', () => {
     vi.unstubAllGlobals()
   })
 
+  it('rejects unsupported token configs locally before saving or testing', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { createAdminApi } = await import('../admin/services/admin-api')
+    const api = createAdminApi()
+    const config = validConfig({
+      apiEndpoint: 'https://music.example.com/api',
+      apiToken: 'private-token',
+      playlists: [{ server: 'netease', playlistId: '123' }],
+    })
+    await expect(api.saveConfig(config)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('暂不支持'),
+    })
+    await expect(api.testMusicApi(config)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('暂不支持'),
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps unauthenticated callbacks scoped to the client instance', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse({ error: '未授权' }, { status: 401 })),
+        ),
+    )
+    const { createAdminApi } = await import('../admin/services/admin-api')
+    const firstExpired = vi.fn()
+    const secondExpired = vi.fn()
+    const first = createAdminApi({ onUnauthenticated: firstExpired })
+    const second = createAdminApi({ onUnauthenticated: secondExpired })
+    await first.fetchConfig()
+    expect(firstExpired).toHaveBeenCalledTimes(1)
+    expect(secondExpired).not.toHaveBeenCalled()
+    await second.fetchConfig()
+    expect(firstExpired).toHaveBeenCalledTimes(1)
+    expect(secondExpired).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mutate Vue auth state when using an unbound service client', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ authenticated: false }))
+      .mockResolvedValueOnce(jsonResponse({ success: true }))
+      .mockResolvedValueOnce(jsonResponse({ error: '未授权' }, { status: 401 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { useAdminAuth } = await import('../admin/composables/useAdminAuth')
+    const { createAdminApi } = await import('../admin/services/admin-api')
+    const auth = useAdminAuth()
+    await auth.login('password')
+    await expect(createAdminApi().fetchConfig()).resolves.toBeNull()
+    expect(auth.authenticated.value).toBe(true)
+  })
+
+  it('does not expire the host session for a passive update check returning 401', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse({ error: '未授权' }, { status: 401 })),
+        ),
+    )
+    const { createAdminApi } = await import('../admin/services/admin-api')
+    const onUnauthenticated = vi.fn()
+    const result = await createAdminApi({ onUnauthenticated }).checkUpdate(
+      '0.2.1',
+      '',
+      false,
+      undefined,
+      { markUnauthenticated: false },
+    )
+    expect(result).toEqual({ ok: false, error: '未授权' })
+    expect(onUnauthenticated).not.toHaveBeenCalled()
+  })
+
   it('marks admin auth as expired when config loading receives 401', async () => {
     const fetchMock = vi
       .fn()
@@ -34,7 +114,8 @@ describe('admin-api', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { useAdminAuth } = await import('../admin/composables/useAdminAuth')
-    const { fetchConfig } = await import('../admin/services/admin-api')
+    const { useAdminApi } = await import('../admin/composables/useAdminApi')
+    const { fetchConfig } = useAdminApi()
     const auth = useAdminAuth()
 
     await expect(auth.login('password')).resolves.toBe(true)
@@ -57,7 +138,8 @@ describe('admin-api', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { useAdminAuth } = await import('../admin/composables/useAdminAuth')
-    const { saveConfig } = await import('../admin/services/admin-api')
+    const { useAdminApi } = await import('../admin/composables/useAdminApi')
+    const { saveConfig } = useAdminApi()
     const auth = useAdminAuth()
 
     await expect(auth.login('password')).resolves.toBe(true)
@@ -89,7 +171,8 @@ describe('admin-api', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { useAdminAuth } = await import('../admin/composables/useAdminAuth')
-    const { saveConfig } = await import('../admin/services/admin-api')
+    const { useAdminApi } = await import('../admin/composables/useAdminApi')
+    const { saveConfig } = useAdminApi()
     const auth = useAdminAuth()
 
     await expect(auth.login('password')).resolves.toBe(true)
@@ -123,7 +206,8 @@ describe('admin-api', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { useAdminAuth } = await import('../admin/composables/useAdminAuth')
-    const { saveConfig } = await import('../admin/services/admin-api')
+    const { useAdminApi } = await import('../admin/composables/useAdminApi')
+    const { saveConfig } = useAdminApi()
     const auth = useAdminAuth()
 
     await expect(auth.login('password')).resolves.toBe(true)
@@ -166,7 +250,8 @@ describe('admin-api', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { useAdminAuth } = await import('../admin/composables/useAdminAuth')
-    const { checkUpdate } = await import('../admin/services/admin-api')
+    const { useAdminApi } = await import('../admin/composables/useAdminApi')
+    const { checkUpdate } = useAdminApi()
     const auth = useAdminAuth()
 
     await expect(auth.login('password')).resolves.toBe(true)
@@ -202,7 +287,8 @@ describe('admin-api', () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ sha: 'commit-next' }))
     vi.stubGlobal('fetch', fetchMock)
 
-    const { saveConfig } = await import('../admin/services/admin-api')
+    const { useAdminApi } = await import('../admin/composables/useAdminApi')
+    const { saveConfig } = useAdminApi()
     const current = validConfig({
       siteIcon: './icon.png',
     })
@@ -219,7 +305,8 @@ describe('admin-api', () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
-    const { saveConfig } = await import('../admin/services/admin-api')
+    const { useAdminApi } = await import('../admin/composables/useAdminApi')
+    const { saveConfig } = useAdminApi()
     const result = await saveConfig(
       validConfig({
         localTracks: [{ id: 'track-1', title: '', artist: '', audio: '' }],
@@ -246,7 +333,8 @@ describe('admin-api', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { checkUpdate } = await import('../admin/services/admin-api')
+    const { useAdminApi } = await import('../admin/composables/useAdminApi')
+    const { checkUpdate } = useAdminApi()
     const result = await checkUpdate('0.2.0', 'https://proxy.example/?url={url}', true)
 
     expect(result).toEqual({ ok: false, error: 'Resource not accessible' })

--- a/src/tests/admin-asset-transaction.test.ts
+++ b/src/tests/admin-asset-transaction.test.ts
@@ -21,13 +21,7 @@ vi.mock('../admin/composables/useAdminAuth', () => ({
   useAdminAuth: () => ({ logout: vi.fn() }),
 }))
 
-vi.mock('../admin/services/admin-api', () => ({
-  fetchConfig: adminApiMock.fetchConfig,
-  saveConfig: adminApiMock.saveConfig,
-  checkUpdate: adminApiMock.checkUpdate,
-  triggerUpdate: adminApiMock.triggerUpdate,
-  fetchUpdateStatus: adminApiMock.fetchUpdateStatus,
-}))
+vi.mock('../admin/composables/useAdminApi', () => ({ useAdminApi: () => adminApiMock }))
 
 vi.mock('../generated/app-version', () => ({
   APP_VERSION: '0.1.0',

--- a/src/tests/admin-components.test.ts
+++ b/src/tests/admin-components.test.ts
@@ -13,13 +13,7 @@ const adminApiMock = vi.hoisted(() => ({
   testMusicApi: vi.fn(),
 }))
 
-vi.mock('../admin/services/admin-api', () => ({
-  MAX_UPLOAD_BYTES: 25 * 1024 * 1024,
-  MAX_UPLOAD_SIZE_LABEL: '25MB',
-  changePassword: adminApiMock.changePassword,
-  uploadFile: adminApiMock.uploadFile,
-  testMusicApi: adminApiMock.testMusicApi,
-}))
+vi.mock('../admin/composables/useAdminApi', () => ({ useAdminApi: () => adminApiMock }))
 
 function config(patch: Partial<MusicConfig> = {}): MusicConfig {
   return {
@@ -39,6 +33,18 @@ describe('admin consistency components', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     document.body.innerHTML = ''
+  })
+
+  it('explains token playback limitations and lets users clear a legacy token', async () => {
+    const wrapper = mount(SiteSettingsEditor, {
+      props: { config: config({ apiToken: 'legacy-token' }) },
+    })
+    expect(wrapper.text()).toContain('暂不支持 Token 音源')
+    await wrapper.find('input[placeholder="暂不支持，请留空"]').setValue('')
+    const updated = wrapper.emitted('update:config')?.at(-1)?.[0]
+    expect(updated).not.toHaveProperty('apiToken')
+    expect(updated).toMatchObject({ siteName: 'Meliora' })
+    wrapper.unmount()
   })
 
   it('requires an 8 character password before changing admin password', async () => {

--- a/src/tests/beat-visuals.test.ts
+++ b/src/tests/beat-visuals.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createBeatVisualRenderer } from '../utils/beat-visuals'
+
+describe('beat visual renderer', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    vi.restoreAllMocks()
+  })
+
+  it('updates newly mounted secondary targets even when the sample is unchanged', () => {
+    const first = document.createElement('div')
+    const second = document.createElement('div')
+    const nodes = [first]
+    document.body.append(first)
+    const firstWrite = vi.spyOn(first.style, 'setProperty')
+    const renderer = createBeatVisualRenderer({ getBeatTargets: () => nodes })
+    renderer.renderBeat(0.4, 0.2)
+    renderer.renderBeat(0.4, 0.2)
+    expect(firstWrite).toHaveBeenCalledTimes(2)
+    nodes.push(second)
+    document.body.append(second)
+    renderer.renderBeat(0.4, 0.2)
+    expect(firstWrite).toHaveBeenCalledTimes(2)
+    expect(second.style.getPropertyValue('--beat-level')).toBe('0.400')
+    expect(second.style.getPropertyValue('--beat-sustain')).toBe('0.200')
+  })
+
+  it('skips detached nodes and restores values after remounting', () => {
+    const node = document.createElement('div')
+    const renderer = createBeatVisualRenderer({ getBeatTargets: () => [null, node] })
+    document.body.append(node)
+    renderer.renderBeat(0.5, 0.1)
+    node.remove()
+    node.style.removeProperty('--beat-level')
+    renderer.renderBeat(0.5, 0.1)
+    expect(node.style.getPropertyValue('--beat-level')).toBe('')
+    document.body.append(node)
+    renderer.renderBeat(0.5, 0.1)
+    expect(node.style.getPropertyValue('--beat-level')).toBe('0.500')
+  })
+
+  it('clamps spectrum levels, deduplicates writes and handles new targets', () => {
+    const first = document.createElement('div')
+    const second = document.createElement('div')
+    const nodes = [first]
+    document.body.append(first)
+    const write = vi.spyOn(first.style, 'setProperty')
+    const renderer = createBeatVisualRenderer({ getSpectrumTargets: () => nodes })
+    renderer.renderSpectrum([-1, 0.5, 2])
+    renderer.renderSpectrum([-1, 0.5, 2])
+    expect(write).toHaveBeenCalledTimes(3)
+    nodes.push(second)
+    document.body.append(second)
+    renderer.renderSpectrum([-1, 0.5, 2])
+    expect(second.style.getPropertyValue('--spectrum-level-0')).toBe('8.0%')
+    expect(second.style.getPropertyValue('--spectrum-level-1')).toBe('50.0%')
+    expect(second.style.getPropertyValue('--spectrum-level-2')).toBe('100.0%')
+    renderer.renderSpectrum([0, 0, 0])
+    expect(first.style.getPropertyValue('--spectrum-level-1')).toBe('8.0%')
+  })
+})

--- a/src/tests/config-schema.test.ts
+++ b/src/tests/config-schema.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { validateMusicConfig } from '../../shared/config-schema'
+import { TOKEN_PLAYBACK_UNSUPPORTED, getPlaybackSupportError } from '../../shared/playback-support'
+import type { MusicConfig } from '../../shared/music-config'
 
 const validConfig = {
   siteName: 'Meliora',
@@ -258,5 +260,21 @@ describe('validateMusicConfig', () => {
 
     expect(result.valid).toBe(false)
     expect(result.errors.some((error) => error.includes('receivePrereleaseUpdates'))).toBe(true)
+  })
+})
+
+describe('getPlaybackSupportError', () => {
+  it('rejects a token-protected source while a playlist is still enabled', () => {
+    expect(getPlaybackSupportError({ ...validConfig, apiToken: 'secret' } as MusicConfig)).toBe(
+      TOKEN_PLAYBACK_UNSUPPORTED,
+    )
+  })
+
+  it('tolerates a config that has no playlists at all', () => {
+    // fetchConfig 把 /api/config 的原始 JSON 直接断言成 MusicConfig,不经校验:
+    // 旧配置或被截断的配置里 playlists 可能压根不存在,兼容读取不能在这里抛
+    const legacy = { siteName: 'Meliora', apiEndpoint: 'https://api.example.com' }
+    expect(() => getPlaybackSupportError(legacy as MusicConfig)).not.toThrow()
+    expect(getPlaybackSupportError({ ...legacy, apiToken: 'secret' } as MusicConfig)).toBeNull()
   })
 })

--- a/src/tests/use-beat-analyser.test.ts
+++ b/src/tests/use-beat-analyser.test.ts
@@ -2,6 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { useBeatAnalyser } from '../composables/useBeatAnalyser'
+import { createBeatVisualRenderer } from '../utils/beat-visuals'
+
+function createHarness(setup: () => Record<string, unknown>) {
+  return defineComponent({ setup, render: () => h('div') })
+}
 
 class AudioNodeMock {
   connections: unknown[] = []
@@ -100,19 +105,14 @@ describe('useBeatAnalyser', () => {
     const onEqFiltersReady = vi.fn()
     const players = [new Audio('/1.mp3'), new Audio('/2.mp3'), new Audio('/3.mp3')]
 
-    const Harness = defineComponent({
-      setup() {
-        const analyser = useBeatAnalyser({
-          players,
-          getActiveAudio: () => players[0]!,
-          isPlaying: ref(true),
-          onEqFiltersReady,
-        })
-        return { analyser }
-      },
-      render() {
-        return h('div')
-      },
+    const Harness = createHarness(() => {
+      const analyser = useBeatAnalyser({
+        players,
+        getActiveAudio: () => players[0]!,
+        isPlaying: ref(true),
+        onEqFiltersReady,
+      })
+      return { analyser }
     })
 
     const wrapper = mount(Harness)
@@ -185,19 +185,19 @@ describe('useBeatAnalyser beat detection', () => {
     const activeAudio =
       options.activeAudio ?? ({ paused: false, currentTime: 0 } as HTMLAudioElement)
     let analyserApi: ReturnType<typeof useBeatAnalyser> | null = null
-    const Harness = defineComponent({
-      setup() {
-        analyserApi = useBeatAnalyser({
-          players: [activeAudio],
-          getActiveAudio: () => activeAudio,
-          isPlaying: ref(true),
+    const Harness = createHarness(() => {
+      analyserApi = useBeatAnalyser({
+        players: [activeAudio],
+        getActiveAudio: () => activeAudio,
+        isPlaying: ref(true),
+        onSpectrum: createBeatVisualRenderer({
           getSpectrumTargets: options.spectrumTarget ? () => [options.spectrumTarget] : undefined,
-          onTainted: options.onTainted,
-          beatVisualDelay:
-            options.beatVisualDelay === undefined ? undefined : ref(options.beatVisualDelay),
-        })
-        return () => h('div')
-      },
+        }).renderSpectrum,
+        onTainted: options.onTainted,
+        beatVisualDelay:
+          options.beatVisualDelay === undefined ? undefined : ref(options.beatVisualDelay),
+      })
+      return {}
     })
     mount(Harness)
     const analyser = analyserApi as unknown as ReturnType<typeof useBeatAnalyser>

--- a/src/tests/use-update-status.test.ts
+++ b/src/tests/use-update-status.test.ts
@@ -6,10 +6,7 @@ const adminApiMock = vi.hoisted(() => ({
   fetchUpdateStatus: vi.fn(),
 }))
 
-vi.mock('../admin/services/admin-api', () => ({
-  triggerUpdate: adminApiMock.triggerUpdate,
-  fetchUpdateStatus: adminApiMock.fetchUpdateStatus,
-}))
+vi.mock('../admin/composables/useAdminApi', () => ({ useAdminApi: () => adminApiMock }))
 
 function flushPromises() {
   return Promise.resolve()

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -1,54 +1,16 @@
-export type MusicServer = 'netease' | 'tencent'
+export type {
+  MusicServer,
+  MetingPlaylistConfig,
+  LocalTrackConfig,
+  UmamiConfig,
+  GoogleAnalyticsConfig,
+  PublicMusicConfig,
+  MusicConfig,
+} from '../../shared/music-config'
 export type PlayMode = 'sequence' | 'loop' | 'single' | 'shuffle'
 export type LyricAvailability = 'available' | 'loading' | 'unavailable'
 export type LyricStatus = 'idle' | 'loading' | 'ready' | 'empty' | 'error'
 export type EqPresetId = 'flat' | 'pop' | 'rock' | 'jazz' | 'vocal' | 'bass-boost' | 'custom'
-
-export interface MetingPlaylistConfig {
-  server: MusicServer
-  playlistId: string
-  enabled?: boolean
-}
-
-export interface LocalTrackConfig {
-  id: string
-  title: string
-  artist: string
-  audio: string
-  album?: string
-  cover?: string
-  lyrics?: string
-}
-
-export interface UmamiConfig {
-  enabled?: boolean
-  scriptUrl?: string
-  websiteId?: string
-}
-
-export interface GoogleAnalyticsConfig {
-  enabled?: boolean
-  measurementId?: string
-}
-
-export interface PublicMusicConfig {
-  siteName: string
-  siteIcon?: string
-  apiEndpoint: string
-  umami?: UmamiConfig
-  googleAnalytics?: GoogleAnalyticsConfig
-  googleSiteVerification?: string
-  customCss?: string
-  customJs?: string
-  playlists: MetingPlaylistConfig[]
-  localTracks: LocalTrackConfig[]
-}
-
-export interface MusicConfig extends PublicMusicConfig {
-  apiToken?: string
-  githubProxy?: string
-  receivePrereleaseUpdates?: boolean
-}
 
 /** 音节时间轴来源。目前只有一种:歌词文件自带的字级时间轴。
  *  没有真实逐字数据的行不做插值合成,整行高亮即可 */

--- a/src/utils/beat-visuals.ts
+++ b/src/utils/beat-visuals.ts
@@ -1,0 +1,47 @@
+/** DOM 渲染适配器：宿主选择目标，分析器只传递数值，高频写入不经过 Vue。 */
+export interface BeatVisualTargets {
+  getBeatTargets?: () => readonly (HTMLElement | null | undefined)[]
+  getSpectrumTargets?: () => readonly (HTMLElement | null | undefined)[]
+}
+
+export function createBeatVisualRenderer(targets: BeatVisualTargets) {
+  // 按节点去重，避免主节点不变时遗漏新挂载的第二个目标；WeakMap 不保留已卸载节点。
+  const beatValues = new WeakMap<HTMLElement, string>()
+  const spectrumValues = new WeakMap<HTMLElement, string>()
+
+  function renderBeat(level: number, sustain: number): void {
+    const nextLevel = level.toFixed(3)
+    const nextSustain = sustain.toFixed(3)
+    const next = `${nextLevel}/${nextSustain}`
+    for (const el of targets.getBeatTargets?.() ?? []) {
+      if (!el) continue
+      if (!el.isConnected) {
+        beatValues.delete(el)
+        continue
+      }
+      if (beatValues.get(el) === next) continue
+      el.style.setProperty('--beat-level', nextLevel)
+      el.style.setProperty('--beat-sustain', nextSustain)
+      beatValues.set(el, next)
+    }
+  }
+
+  function renderSpectrum(levels: readonly number[]): void {
+    const values = levels.map(
+      (level) => `${(Math.max(0.08, Math.min(1, level)) * 100).toFixed(1)}%`,
+    )
+    const next = values.join('/')
+    for (const el of targets.getSpectrumTargets?.() ?? []) {
+      if (!el) continue
+      if (!el.isConnected) {
+        spectrumValues.delete(el)
+        continue
+      }
+      if (spectrumValues.get(el) === next) continue
+      values.forEach((value, index) => el.style.setProperty(`--spectrum-level-${index}`, value))
+      spectrumValues.set(el, next)
+    }
+  }
+
+  return { renderBeat, renderSpectrum }
+}

--- a/src/views/PlayerView.vue
+++ b/src/views/PlayerView.vue
@@ -59,7 +59,7 @@
   const { currentTrack, currentTrackId, currentTime, duration, isPlaying, settings, tracks } =
     storeToRefs(store)
   // --beat-level 高频写入的目标节点：封面层(其 ::after 亮层只改 opacity)与叠加层(::before 光晕),
-  // useBeatAnalyser 会在 RAF 中直接 setProperty 到这些节点，跳过根 :style 的样式重算。
+  // 节拍渲染适配器会在 RAF 中直接 setProperty 到这些节点，跳过根 :style 的样式重算。
   // 两层的 filter 都是静态的:每帧变化的只有 opacity / transform,不会整屏重栅格化。
   const artworkBackgroundRef = ref<HTMLElement | null>(null)
   const backgroundOverlayRef = ref<HTMLElement | null>(null)
@@ -318,7 +318,7 @@
   }))
   const playModeIcon = computed(() => PLAY_MODE_META[settings.value.playMode].icon)
   const beatStyle = computed(() => ({
-    // --beat-level 已移出本 computed：高频写入由 useBeatAnalyser 直接 setProperty 到目标节点，
+    // --beat-level 已移出本 computed：高频写入由节拍渲染适配器直接 setProperty 到目标节点，
     // 避免根元素 :style 改变触发整棵子树（233 个节点）样式重算。
     '--accent': accent.value,
     '--accent-soft': accentSoft.value,
@@ -1131,7 +1131,7 @@
     transition: background 0.46s ease;
   }
   // 叠加层上的节奏光晕:只有一团很淡的主题色,补一点色彩呼吸;主要的"变亮"由封面亮层承担。
-  // --beat-level / --beat-sustain 由 useBeatAnalyser 每帧直写到 .background-overlay,伪元素继承后参与 calc;
+  // --beat-level / --beat-sustain 由节拍渲染适配器每帧直写到 .background-overlay,伪元素继承后参与 calc;
   // opacity / transform 不挂 transition,避免每帧写入被过渡拦截;background 的过渡只在换歌换色时触发。
   .background-overlay::before {
     content: '';


### PR DESCRIPTION
## 描述

本PR是和ABloom在线下一起交流修复的

启用远程歌单并填写 API Token 时，原先的服务端测试会携带 Token 成功，但播放器不携带 Token，实际加载可能返回 401。本 PR 保持播放器直接访问公开音源：前后端在保存及测试前明确拒绝这类配置，旧配置仍可读取并清除 Token 或禁用歌单。服务端测试与播放器共享 URL 构造，保留端点已有查询参数，并说明服务端连通不代表浏览器跨域访问可用。

公共音乐配置类型迁至 shared，后端不再导入前端类型；后台 API 改为通过客户端工厂注入鉴权失效回调，由 composable 更新 Vue 状态；节拍分析仅通过回调输出数值，独立 DOM 适配器负责逐节点去重与渲染。增加依赖方向的 Lint 约束和回归测试。

## 相关 Issue

无。基于 preview 分支的架构审核修复。

## 改动类型

- [x] Bug 修复 (fix)
- [x] 重构 (refactor)
- [x] 测试 (test)
- [x] 文档更新 (docs)

## 测试情况

使用锁定依赖，直接执行各脚本对应的本地 Node 入口：

- [x] 全量 Vitest：73 个测试文件、702 项测试通过（包含构建产物泄漏检查）
- [x] vue-tsc -b --force
- [x] ESLint，零警告
- [x] Prettier 全仓检查
- [x] 配置生成、Vite 生产构建、Service Worker 缓存名注入
- [x] 新增 Token 拒绝/旧配置禁用、客户端鉴权回调隔离、查询参数保留、渲染节点重挂载等测试
- [ ] 真实浏览器音频及线上部署验证

## 注意事项

PR 目标为 preview。播放器仍读取构建期公开配置，配置发布继续走现有重新构建流程；不增加音源代理或跨域管理 API。已有 Token 配置可打开，但启用相关歌单时需清空 Token 并更换公开接口，或禁用歌单后再保存。

上游 PR Validation 工作流目前只匹配 main，preview PR 不会自动触发该工作流。本地验证结果不代表上游 CI 已执行。
